### PR TITLE
Override textarea component

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ React.render(<Demo />, container);
 | split | Set split string before and after selected mention | string | ' ' |
 | validateSearch | Customize trigger search logic | (text: string, props: MentionsProps) => void | - |
 | value | Set value of mentions | string | - |
+| inputComponent | The component to render as the input | React.Component | 'textarea' |
+| inputRefKey | The name of the textbox's ref prop in `inputComponent` | string | 'ref' |
 | onChange | Trigger when value changed |(text: string) => void | - |
 | onSelect | Trigger when user select the option | (option: OptionProps, prefix: string) => void | - |
 | onSearch | Trigger when prefix hit | (text: string, prefix: string) => void | - |

--- a/examples/autosize.js
+++ b/examples/autosize.js
@@ -1,0 +1,45 @@
+/* eslint no-console: 0 */
+
+import React from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
+import Mentions from '../src';
+import '../assets/index.less';
+
+const { Option } = Mentions;
+
+class Demo extends React.Component {
+  onSelect = (option, prefix) => {
+    console.log('Select:', prefix, '-', option.value);
+  };
+
+  onFocus = () => {
+    console.log('onFocus');
+  };
+
+  onBlur = () => {
+    console.log('onBlur');
+  };
+
+  render() {
+    return (
+      <div>
+        <Mentions
+          inputComponent={TextareaAutosize}
+          inputRefKey="inputRef"
+          autoFocus
+          rows={3}
+          defaultValue="Hello World"
+          onSelect={this.onSelect}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+        >
+          <Option value="light">Light</Option>
+          <Option value="bamboo">Bamboo</Option>
+          <Option value="cat">Cat</Option>
+        </Mentions>
+      </div>
+    );
+  }
+}
+
+export default Demo;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "np": "^5.0.3",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "typescript": "^3.2.2"
+    "typescript": "^3.2.2",
+    "react-textarea-autosize": "^7.1.2"
   },
   "dependencies": {
     "classnames": "^2.2.6",

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -37,6 +37,8 @@ export interface MentionsProps extends BaseTextareaAttrs {
   value?: string;
   filterOption?: false | typeof defaultFilterOption;
   validateSearch?: typeof defaultValidateSearch;
+  inputComponent?: React.Component;
+  inputRefKey?: string;
   onChange?: (text: string) => void;
   onSelect?: (option: OptionProps, prefix: string) => void;
   onSearch?: (text: string, prefix: string) => void;
@@ -69,6 +71,8 @@ class Mentions extends React.Component<MentionsProps, MentionsState> {
     validateSearch: defaultValidateSearch,
     filterOption: defaultFilterOption,
     notFoundContent: 'Not Found',
+    inputComponent: 'textarea',
+    inputRefKey: 'ref',
     rows: 1,
   };
 
@@ -355,6 +359,8 @@ class Mentions extends React.Component<MentionsProps, MentionsState> {
       autoFocus,
       notFoundContent,
       getPopupContainer,
+      inputComponent: InputComponent,
+      inputRefKey,
       ...restProps
     } = this.props;
 
@@ -375,9 +381,9 @@ class Mentions extends React.Component<MentionsProps, MentionsState> {
 
     return (
       <div className={classNames(prefixCls, className)} style={style}>
-        <textarea
+        <InputComponent
           autoFocus={autoFocus}
-          ref={this.setTextAreaRef}
+          {...{[inputRefKey]: this.setTextAreaRef}}
           value={value}
           {...inputProps}
           onChange={this.onChange}


### PR DESCRIPTION
In order to be able to replace the inner textarea component, I added two optional props.
* `inputComponent` is the actual component that will be rendered.
* `inputRefKey` is the name of the prop that should return the ref for the textarea or an element with the same interface/functions.

This allows for example to use the 'react-textarea-autosize' package to add auto-size functionality.