### PR TITLE
support client-provided onKeyUp handler

### DIFF
--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -168,13 +168,18 @@ class Mentions extends React.Component<MentionsProps, MentionsState> {
   public onKeyUp: React.KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
     const { key, which } = event;
     const { measureText: prevMeasureText, measuring } = this.state;
-    const { prefix = '', onSearch, validateSearch } = this.props;
+    const { prefix = '', onKeyUp: clientOnKeyUp, onSearch, validateSearch } = this.props;
     const target = event.target as HTMLTextAreaElement;
     const selectionStartText = getBeforeSelectionText(target);
     const { location: measureIndex, prefix: measurePrefix } = getLastMeasureIndex(
       selectionStartText,
       prefix,
     );
+
+    // If the client implements an onKeyUp handler, call it
+    if (clientOnKeyUp) {
+      clientOnKeyUp(event);
+    }
 
     // Skip if match the white key list
     if ([KeyCode.ESC, KeyCode.UP, KeyCode.DOWN, KeyCode.ENTER].indexOf(which) !== -1) {

--- a/tests/FullProcess.spec.jsx
+++ b/tests/FullProcess.spec.jsx
@@ -21,7 +21,8 @@ describe('Full Process', () => {
     const onChange = jest.fn();
     const onSelect = jest.fn();
     const onSearch = jest.fn();
-    const wrapper = createMentions({ onChange, onSelect, onSearch });
+    const onKeyUp = jest.fn();
+    const wrapper = createMentions({ onChange, onKeyUp, onSelect, onSearch });
 
     simulateInput(wrapper, '@');
     expect(wrapper.find('DropdownMenu').props().options).toMatchObject([
@@ -49,6 +50,7 @@ describe('Full Process', () => {
       expect.objectContaining({ value: 'cat' }),
       '@',
     );
+    expect(onKeyUp).toHaveBeenCalled();
   });
 
   it('insert into half way', () => {


### PR DESCRIPTION
We have cases where we want to run some extra behavior around the keyUp event, and this would allow us to do so.

As an example: most of our forms submit when the user hits the "Enter" key, but for textareas we often want the response to be adding a newline to the textarea. In that case, we swallow the event and prevent it from bubbling to the form where it would trigger a submit in the textarea's keyUp handler.