### PR TITLE
persist the blur event so clients can use it

### DIFF
--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -243,6 +243,11 @@ class Mentions extends React.Component<MentionsProps, MentionsState> {
   };
 
   public onBlur = (event?: React.FocusEvent<HTMLTextAreaElement>) => {
+    // the timeout causes onBlur to be called async, which causes the react synthetic
+    // event to be nullified. persist it if possible so clients can use it.
+    if (event.persist) {
+      event.persist();
+    }
     this.focusId = window.setTimeout(() => {
       const { onBlur } = this.props;
       this.setState({ isFocus: false });


### PR DESCRIPTION
This fixes a bug where the event that is passed to the `onBlur` prop will be nullified because the code is executed asynchronously using a timeout. I expect there's a good reason why the timeout is necessary; however, if it were not necessary, then removing the timeout would be a simpler and more efficient solution to this problem since `event.persist()` creates a copy of the event.