### PR TITLE
fix: shouldn't call onPressEnter when measuring

### DIFF
--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -211,6 +211,14 @@ class Mentions extends React.Component<MentionsProps, MentionsState> {
     }
   };
 
+  public onPressEnter: React.KeyboardEventHandler<HTMLTextAreaElement> = event => {
+    const { measuring } = this.state;
+    const { onPressEnter } = this.props;
+    if (!measuring && onPressEnter) {
+      onPressEnter(event);
+    }
+  };
+
   public onInputFocus: React.FocusEventHandler<HTMLTextAreaElement> = event => {
     this.onFocus(event);
   };
@@ -369,6 +377,7 @@ class Mentions extends React.Component<MentionsProps, MentionsState> {
           onChange={this.onChange}
           onKeyDown={this.onKeyDown}
           onKeyUp={this.onKeyUp}
+          onPressEnter={this.onPressEnter}
           onFocus={this.onInputFocus}
           onBlur={this.onInputBlur}
         />

--- a/tests/FullProcess.spec.jsx
+++ b/tests/FullProcess.spec.jsx
@@ -98,6 +98,23 @@ describe('Full Process', () => {
     expect(wrapper.state().measuring).toBeFalsy();
   });
 
+  it('should not call onPressEnter when measuring', () => {
+    const onPressEnter = jest.fn();
+    const wrapper = createMentions({ onPressEnter });
+
+    simulateInput(wrapper, '@');
+    wrapper.find('textarea').simulate('keyDown', {
+      keyCode: KeyCode.ENTER,
+    });
+    expect(onPressEnter).not.toHaveBeenCalled();
+
+    simulateInput(wrapper, 'test');
+    wrapper.find('textarea').simulate('keyDown', {
+      keyCode: KeyCode.ENTER,
+    });
+    expect(onPressEnter).toHaveBeenCalled();
+  });
+
   it('ESC', () => {
     const wrapper = createMentions();
 


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/26381