### PR TITLE
fix: can't select when option has same value

### DIFF
--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -27,19 +27,19 @@ class DropdownMenu extends React.Component<DropdownMenuProps, {}> {
     return (
       <Menu
         prefixCls={`${prefixCls}-menu`}
-        activeKey={activeOption.value}
+        activeKey={activeOption.key}
         onSelect={({ key }) => {
-          const option = options.find(({ value }) => value === key);
+          const option = options.find(({ key: optionKey }) => optionKey === key);
           selectOption(option);
         }}
         onFocus={onFocus}
         onBlur={onBlur}
       >
         {options.map((option, index) => {
-          const { value, disabled, children, className, style } = option;
+          const { key, disabled, children, className, style } = option;
           return (
             <MenuItem
-              key={value}
+              key={key}
               disabled={disabled}
               className={className}
               style={style}

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -297,7 +297,7 @@ class Mentions extends React.Component<MentionsProps, MentionsState> {
     const targetMeasureText = measureText || this.state.measureText || '';
     const { children, filterOption } = this.props;
     const list = toArray(children)
-      .map(({ props }: { props: OptionProps }) => props)
+      .map(({ props, key }: { props: OptionProps, key: string }) => ({ ...props, key: key || props.value }))
       .filter((option: OptionProps) => {
         /** Return all result if `filterOption` is false. */
         if (filterOption === false) {

--- a/src/Option.tsx
+++ b/src/Option.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 export interface OptionProps {
   value?: string;
+  key?: string;
   disabled?: boolean;
   children?: React.ReactNode;
   className?: string;

--- a/tests/FullProcess.spec.jsx
+++ b/tests/FullProcess.spec.jsx
@@ -115,6 +115,22 @@ describe('Full Process', () => {
     expect(onPressEnter).toHaveBeenCalled();
   });
 
+  it('should support same value', () => {
+    const wrapper = mount(
+      <Mentions>
+        <Option value="bamboo">Bamboo</Option>
+        <Option value="bamboo" key="same_bamboo">
+          Bamboo
+        </Option>
+        <Option value="light">Light</Option>
+        <Option value="cat">Cat</Option>
+      </Mentions>,
+    );
+
+    simulateInput(wrapper, '@');
+    expect(wrapper.find('.rc-mentions-dropdown-menu-item-active').length).toBe(1);
+  });
+
   it('ESC', () => {
     const wrapper = createMentions();
 


### PR DESCRIPTION
fix https://github.com/react-component/mentions/issues/14
https://github.com/ant-design/ant-design/issues/18435

Mentions.Option在有相同value的情况下，@后的下拉框无法选择，同时会有key的错误

我们公司有人重名，所以就出现了value相同的情况，但是key总是唯一的

![](https://s1.ax1x.com/2020/08/28/dI9on0.png)
