### PR TITLE
fix:dynamic mention options do not always load

### DIFF
--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -189,6 +189,7 @@ class Mentions extends React.Component<MentionsProps, MentionsState> {
       if (validateMeasure) {
         if (
           key === measurePrefix ||
+          key === 'Shift'||
           measuring ||
           (measureText !== prevMeasureText && matchOption)
         ) {


### PR DESCRIPTION
#36

问题复现：

按下  `shift` ，再按下  `@`

此时分两种情况：

1. 先抬起  `@` ，再抬起  `shift` ，则可以正常显示选项
2. 反之，先抬起 `shift` ，再抬起  `@` ，则无法显示选项

期望：无论先抬起@，还是先抬起shift，都应正常显示选择

已解决该问题