### PR TITLE
feat: Do not respond to the Enter event when data is loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ React.render(<Demo />, container);
 | prefix            | Set trigger prefix keyword                                                                              | `string \| string[]`                                       | '@'         |
 | rows              | Set row count                                                                                           | `number`                                                   | 1           |
 | split             | Set split string before and after selected mention                                                      | `string`                                                   | ' '         |
+| silent            | Used in transition phase, does not respond to keyboard enter events when equal to `true`                | `boolean`                                                  | `false`     |
 | validateSearch    | Customize trigger search logic                                                                          | `(text: string, props: MentionsProps) => void`             | -           |
 | value             | Set value of mentions                                                                                   | `string`                                                   | -           |
 | onChange          | Trigger when value changed                                                                              | `(text: string) => void`                                   | -           |

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -55,6 +55,7 @@ export interface MentionsProps extends BaseTextareaAttrs {
   prefix?: string | string[];
   prefixCls?: string;
   value?: string;
+  loading?: boolean;
   filterOption?: false | typeof defaultFilterOption;
   validateSearch?: typeof defaultValidateSearch;
   onChange?: (text: string) => void;
@@ -101,6 +102,7 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
       options,
       open,
       allowClear,
+      loading,
 
       // Events
       validateSearch = defaultValidateSearch,
@@ -330,6 +332,9 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
       } else if (which === KeyCode.ENTER) {
         // Measure hit
         event.preventDefault();
+        // loading skip
+        if (loading) return;
+
         if (!mergedOptions.length) {
           stopMeasure();
           return;

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -333,7 +333,9 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
         // Measure hit
         event.preventDefault();
         // loading skip
-        if (loading) return;
+        if (loading) {
+          return;
+        }
 
         if (!mergedOptions.length) {
           stopMeasure();

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -55,7 +55,7 @@ export interface MentionsProps extends BaseTextareaAttrs {
   prefix?: string | string[];
   prefixCls?: string;
   value?: string;
-  loading?: boolean;
+  silent?: boolean;
   filterOption?: false | typeof defaultFilterOption;
   validateSearch?: typeof defaultValidateSearch;
   onChange?: (text: string) => void;
@@ -102,7 +102,7 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
       options,
       open,
       allowClear,
-      loading,
+      silent,
 
       // Events
       validateSearch = defaultValidateSearch,
@@ -333,7 +333,7 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
         // Measure hit
         event.preventDefault();
         // loading skip
-        if (loading) {
+        if (silent) {
           return;
         }
 

--- a/tests/Mentions.spec.tsx
+++ b/tests/Mentions.spec.tsx
@@ -44,15 +44,11 @@ describe('Mentions', () => {
     jest.useFakeTimers();
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   describe('focus test', () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
     it('autoFocus', () => {
       const { container } = renderMentions({ autoFocus: true });
       expect(document.activeElement).toBe(container.querySelector('textarea'));

--- a/tests/Mentions.spec.tsx
+++ b/tests/Mentions.spec.tsx
@@ -40,6 +40,10 @@ describe('Mentions', () => {
     return render(createMentions(props));
   }
 
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
   describe('focus test', () => {
     beforeEach(() => {
       jest.useFakeTimers();
@@ -134,6 +138,24 @@ describe('Mentions', () => {
         target: { value: 'bamboo' },
       });
       expect(onChange).toHaveBeenCalledWith('bamboo');
+    });
+
+    it('Keyboard Enter event', () => {
+      const { container, rerender } = renderMentions();
+      simulateInput(container, '@lig');
+      fireEvent.keyDown(container.querySelector('textarea'), {
+        which: KeyCode.ENTER,
+        keyCode: KeyCode.ENTER,
+      });
+      expect(container.querySelector('textarea').value).toBe('@light ');
+
+      rerender(createMentions({ loading: true }));
+      simulateInput(container, '@lig');
+      fireEvent.keyDown(container.querySelector('textarea'), {
+        which: KeyCode.ENTER,
+        keyCode: KeyCode.ENTER,
+      });
+      expect(container.querySelector('textarea').value).toBe('@lig');
     });
   });
 

--- a/tests/Mentions.spec.tsx
+++ b/tests/Mentions.spec.tsx
@@ -149,7 +149,7 @@ describe('Mentions', () => {
       });
       expect(container.querySelector('textarea').value).toBe('@light ');
 
-      rerender(createMentions({ loading: true }));
+      rerender(createMentions({ silent: true }));
       simulateInput(container, '@lig');
       fireEvent.keyDown(container.querySelector('textarea'), {
         which: KeyCode.ENTER,


### PR DESCRIPTION
新增 loading 字段
在异步加载数据场景下 当 loading=true 时不响应 Enter 事件
- fix  https://github.com/ant-design/ant-design/issues/49255