### PR TITLE
chore: bump rc-input from 1.5.0 to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/runtime": "^7.22.5",
     "@rc-component/trigger": "^2.0.0",
     "classnames": "^2.2.6",
-    "rc-input": "~1.5.0",
+    "rc-input": "~1.6.0",
     "rc-menu": "~9.14.0",
     "rc-textarea": "~1.7.0",
     "rc-util": "^5.34.1"


### PR DESCRIPTION
chore: bump rc-input from 1.5.0 to 1.6.0