### PR TITLE
fix: react warnings

### DIFF
--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -52,7 +52,11 @@ function DropdownMenu(props: DropdownMenuProps) {
         );
       })}
 
-      {!options.length && <MenuItem disabled>{notFoundContent}</MenuItem>}
+      {!options.length && (
+        <MenuItem key="not-found" disabled>
+          {notFoundContent}
+        </MenuItem>
+      )}
     </Menu>
   );
 }

--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -52,11 +52,7 @@ function DropdownMenu(props: DropdownMenuProps) {
         );
       })}
 
-      {!options.length && (
-        <MenuItem key="not-found" disabled>
-          {notFoundContent}
-        </MenuItem>
-      )}
+      {!options.length && <MenuItem disabled>{notFoundContent}</MenuItem>}
     </Menu>
   );
 }

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -128,6 +128,7 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
 
       // Fix Warning: Received `false` for a non-boolean attribute `visible`.
       // https://github.com/ant-design/ant-design/blob/df933e94efc8f376003bbdc658d64b64a0e53495/components/mentions/demo/render-panel.tsx
+      // @ts-expect-error
       visible,
       // Rest
       ...restProps

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -126,6 +126,9 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
 
       rows = 1,
 
+      // Fix Warning: Received `false` for a non-boolean attribute `visible`.
+      // https://github.com/ant-design/ant-design/blob/df933e94efc8f376003bbdc658d64b64a0e53495/components/mentions/demo/render-panel.tsx
+      visible,
       // Rest
       ...restProps
     } = props;


### PR DESCRIPTION
修复两个 warning。

<img width="925" alt="image" src="https://github.com/user-attachments/assets/32886e5c-95a7-422f-b034-16dee45d0d69">

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/3d34f395-c653-4e5a-9be8-a8962c223df3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 优化了下拉菜单组件的渲染逻辑，提高了性能和效率。

- **错误修复**
	- 修复了提及组件中 `visible` 属性的类型问题，增强了组件的健壮性，减少运行时警告。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->