### PR TITLE
feat: support AZERTY Keyboards (AltGr + à) @ startMeasure

### DIFF
--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -394,7 +394,7 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
           if (
             key === nextMeasurePrefix ||
             key === 'Shift' ||
-            key === 'Meta' ||
+            key === 'Alt' ||
             mergedMeasuring ||
             (nextMeasureText !== mergedMeasureText && matchOption)
           ) {

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -394,6 +394,7 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
           if (
             key === nextMeasurePrefix ||
             key === 'Shift' ||
+            key === 'Meta' ||
             mergedMeasuring ||
             (nextMeasureText !== mergedMeasureText && matchOption)
           ) {

--- a/tests/FullProcess.spec.tsx
+++ b/tests/FullProcess.spec.tsx
@@ -187,4 +187,24 @@ describe('Full Process', () => {
 
     expectMeasuring(container, false);
   });
+
+  it('AltGr + à startMeasure', () => {
+    const onChange = jest.fn();
+    const { container } = createMentions({ onChange });
+    simulateInput(container, '@');
+
+    // AZERTY Keyboards (AltGr + à)
+    fireEvent.keyUp(container.querySelector('textarea'), {
+      keyCode: KeyCode.ALT,
+      which: KeyCode.ALT,
+    });
+    expectMeasuring(container);
+
+    fireEvent.keyDown(container.querySelector('textarea'), {
+      keyCode: KeyCode.ENTER,
+      which: KeyCode.ENTER,
+    });
+
+    expect(onChange).toBeCalledWith('@bamboo ');
+  });
 });


### PR DESCRIPTION
[#50795](https://github.com/ant-design/ant-design/issues/50795) Mentions Component Fails to Detect "@" on AZERTY Keyboards (AltGr + à)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在提及组件中添加对“Meta”和“Alt”键的支持，增强了用户输入的响应能力。
- **测试**
	- 在完整流程测试套件中添加了针对AZERTY键盘布局的测试用例，以验证键盘事件处理的正确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->