### PR TITLE
fix: #297 disabled option can be selected by pressing Enter key

### DIFF
--- a/docs/examples/basic.tsx
+++ b/docs/examples/basic.tsx
@@ -32,6 +32,11 @@ export default () => (
         label: 'Bamboo',
       },
       {
+        value: 'dark',
+        label: 'Dark',
+        disabled: true,
+      },
+      {
         value: 'cat',
         label: 'Cat',
       },

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -297,7 +297,10 @@ const InternalMentions = forwardRef<MentionsRef, MentionsProps>(
     };
 
     const selectOption = (option: OptionProps) => {
-      const { value: mentionValue = '' } = option;
+      const { value: mentionValue = '', disabled } = option;
+      if (disabled) {
+        return;
+      }
       const { text, selectionLocation } = replaceWithMeasure(mergedValue, {
         measureLocation: mergedMeasureLocation,
         targetText: mentionValue,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新增/修复
  - Mentions 组件在选择时会自动跳过被禁用的选项，避免插入无效文本与触发 onSelect；其余输入与状态更新逻辑保持一致，提升一致性与可用性。
- 文档
  - 基础示例新增一个禁用的“Dark”选项（位于 Bamboo 与 Cat 之间），直观展示不可选项在下拉中的显示与交互效果，便于理解实际行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->