### PR TITLE
fix: Prevent auto-scrolling when input is not focused

### DIFF
--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -35,7 +35,6 @@ function DropdownMenu(props: DropdownMenuProps) {
       return;
     }
 
-    // 只有当焦点恰好位于当前文本区域时，才进行滚动操作。
     if (
       textareaRef?.current &&
       document.activeElement !== textareaRef.current.nativeElement

--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -22,6 +22,7 @@ function DropdownMenu(props: DropdownMenuProps) {
     onFocus,
     onBlur,
     onScroll,
+    textareaRef,
   } = React.useContext(MentionsContext);
 
   const { prefixCls, options, opened } = props;
@@ -34,6 +35,14 @@ function DropdownMenu(props: DropdownMenuProps) {
       return;
     }
 
+    // 只有当焦点恰好位于当前文本区域时，才进行滚动操作。
+    if (
+      textareaRef?.current &&
+      document.activeElement !== textareaRef.current.nativeElement
+    ) {
+      return;
+    }
+
     const activeItem = menuRef.current?.findItem?.({ key: activeOption.key });
 
     if (activeItem) {
@@ -42,7 +51,7 @@ function DropdownMenu(props: DropdownMenuProps) {
         inline: 'nearest',
       });
     }
-  }, [activeIndex, activeOption.key, opened]);
+  }, [activeIndex, activeOption.key, opened, textareaRef]);
 
   return (
     <Menu

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -529,6 +529,7 @@ const InternalMentions = forwardRef<MentionsRef, InternalMentionsProps>(
                 onFocus: onDropdownFocus,
                 onBlur: onDropdownBlur,
                 onScroll: onInternalPopupScroll,
+                textareaRef,
               }}
             >
               <KeywordTrigger

--- a/src/MentionsContext.ts
+++ b/src/MentionsContext.ts
@@ -1,6 +1,7 @@
 /* tslint:disable: no-object-literal-type-assertion */
 import * as React from 'react';
 import type { OptionProps } from './Option';
+import { TextAreaRef } from '@rc-component/textarea';
 
 export interface MentionsContextProps {
   notFoundContent: React.ReactNode;
@@ -10,6 +11,7 @@ export interface MentionsContextProps {
   onFocus: React.FocusEventHandler<HTMLElement>;
   onBlur: React.FocusEventHandler<HTMLElement>;
   onScroll: React.UIEventHandler<HTMLElement>;
+  textareaRef: React.MutableRefObject<TextAreaRef>;
 }
 
 // We will never use default, here only to fix TypeScript warning

--- a/tests/DropdownMenu.spec.tsx
+++ b/tests/DropdownMenu.spec.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
-import { render, act } from '@testing-library/react';
-import Mentions, { UnstableContext } from '../src';
+import { render, act, fireEvent } from '@testing-library/react';
+import Mentions from '../src';
 import { simulateInput } from './util';
 
 describe('DropdownMenu', () => {
-  // Generate 20 options for testing scrolling behavior
   const generateOptions = Array.from({ length: 20 }).map((_, index) => ({
     value: `item-${index}`,
     label: `item-${index}`,
   }));
+
+  beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -16,37 +23,72 @@ describe('DropdownMenu', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    jest.clearAllMocks();
   });
 
-  it('should scroll into view when navigating with keyboard', async () => {
-    // Setup component with UnstableContext for testing dropdown behavior
+  it('should scroll into view when navigating with keyboard (Focused)', async () => {
     const { container } = render(
-      <UnstableContext.Provider value={{ open: true }}>
-        <Mentions defaultValue="@" options={generateOptions} />
-      </UnstableContext.Provider>,
+      <Mentions defaultValue="" options={generateOptions} />,
     );
 
-    // Mock scrollIntoView since it's not implemented in JSDOM
+    const textarea = container.querySelector('textarea');
     const scrollIntoViewMock = jest
       .spyOn(HTMLElement.prototype, 'scrollIntoView')
       .mockImplementation(jest.fn());
 
-    // Trigger should not scroll
-    simulateInput(container, '@');
-    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    await act(async () => {
+      textarea.focus();
 
-    for (let i = 0; i < 10; i++) {
-      await act(async () => {
-        jest.advanceTimersByTime(1000);
-        await Promise.resolve();
-      });
-    }
+      simulateInput(container, '@');
 
-    // Verify if scrollIntoView was called
+      jest.runAllTimers();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'ArrowDown', code: 'ArrowDown' });
+      jest.runAllTimers();
+    });
+
     expect(scrollIntoViewMock).toHaveBeenCalledWith({
       block: 'nearest',
       inline: 'nearest',
     });
+
+    scrollIntoViewMock.mockRestore();
+  });
+
+  it('should NOT scroll into view when input is NOT focused', async () => {
+    const { container } = render(
+      <Mentions defaultValue="" options={generateOptions} />,
+    );
+
+    const textarea = container.querySelector('textarea');
+    const scrollIntoViewMock = jest
+      .spyOn(HTMLElement.prototype, 'scrollIntoView')
+      .mockImplementation(jest.fn());
+
+    await act(async () => {
+      textarea.focus();
+      simulateInput(container, '@');
+      jest.runAllTimers();
+    });
+
+    scrollIntoViewMock.mockClear();
+
+    await act(async () => {
+      fireEvent.blur(textarea);
+      jest.runAllTimers();
+    });
+
+    await act(async () => {
+      const menuItems = document.querySelectorAll('.rc-mentions-menu-item');
+      if (menuItems.length > 1) {
+        fireEvent.mouseEnter(menuItems[1]);
+        jest.runAllTimers();
+      }
+    });
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
     scrollIntoViewMock.mockRestore();
   });

--- a/tests/DropdownMenu.spec.tsx
+++ b/tests/DropdownMenu.spec.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
-import { render, act, fireEvent, waitFor } from '@testing-library/react';
-import Mentions from '../src';
+import { render, act } from '@testing-library/react';
+import Mentions, { UnstableContext } from '../src';
 import { simulateInput } from './util';
 
 describe('DropdownMenu', () => {
+  // Generate 20 options for testing scrolling behavior
   const generateOptions = Array.from({ length: 20 }).map((_, index) => ({
     value: `item-${index}`,
     label: `item-${index}`,
   }));
-
-  let originResizeObserver: any;
-  beforeAll(() => {
-    originResizeObserver = (global as any).ResizeObserver;
-    (global as any).ResizeObserver = class ResizeObserver {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    };
-  });
-
-  afterAll(() => {
-    (global as any).ResizeObserver = originResizeObserver;
-  });
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -29,32 +16,33 @@ describe('DropdownMenu', () => {
 
   afterEach(() => {
     jest.useRealTimers();
-    jest.restoreAllMocks();
   });
 
-  it('should scroll into view when navigating with keyboard (Focused)', async () => {
+  it('should scroll into view when navigating with keyboard', async () => {
+    // Setup component with UnstableContext for testing dropdown behavior
     const { container } = render(
-      <Mentions defaultValue="" options={generateOptions} />,
+      <UnstableContext.Provider value={{ open: true }}>
+        <Mentions autoFocus defaultValue="@" options={generateOptions} />
+      </UnstableContext.Provider>,
     );
 
-    const textarea = container.querySelector('textarea');
+    // Mock scrollIntoView since it's not implemented in JSDOM
     const scrollIntoViewMock = jest
       .spyOn(HTMLElement.prototype, 'scrollIntoView')
       .mockImplementation(jest.fn());
 
-    await act(async () => {
-      textarea.focus();
+    // Trigger should not scroll
+    simulateInput(container, '@');
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
-      simulateInput(container, '@');
+    for (let i = 0; i < 10; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      });
+    }
 
-      jest.runAllTimers();
-    });
-
-    await act(async () => {
-      fireEvent.keyDown(textarea, { key: 'ArrowDown', code: 'ArrowDown' });
-      jest.runAllTimers();
-    });
-
+    // Verify if scrollIntoView was called
     expect(scrollIntoViewMock).toHaveBeenCalledWith({
       block: 'nearest',
       inline: 'nearest',
@@ -63,39 +51,25 @@ describe('DropdownMenu', () => {
     scrollIntoViewMock.mockRestore();
   });
 
-  it('should NOT scroll and hit the return statement when input blurs but menu is arguably open', async () => {
+  it('should NOT scroll into view when navigating without focus', async () => {
     const { container } = render(
-      <Mentions defaultValue="" options={generateOptions} />,
+      <UnstableContext.Provider value={{ open: true }}>
+        <Mentions defaultValue="@" options={generateOptions} />
+      </UnstableContext.Provider>,
     );
 
-    const textarea = container.querySelector('textarea');
     const scrollIntoViewMock = jest
       .spyOn(HTMLElement.prototype, 'scrollIntoView')
       .mockImplementation(jest.fn());
 
-    await act(async () => {
-      textarea.focus();
-      simulateInput(container, '@');
-      jest.runAllTimers();
-    });
+    simulateInput(container, '@');
 
-    await waitFor(() => {
-      const menuItems = document.querySelectorAll(
-        '.rc-mentions-dropdown-menu-item',
-      );
-      expect(menuItems.length).toBeGreaterThan(1);
-    });
-
-    const menuItems = document.querySelectorAll(
-      '.rc-mentions-dropdown-menu-item',
-    );
-
-    await act(async () => {
-      fireEvent.mouseEnter(menuItems[1]);
-
-      fireEvent.blur(textarea);
-      jest.runAllTimers();
-    });
+    for (let i = 0; i < 10; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      });
+    }
 
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
 

--- a/tests/DropdownMenu.spec.tsx
+++ b/tests/DropdownMenu.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, act, fireEvent } from '@testing-library/react';
+import { render, act, fireEvent, waitFor } from '@testing-library/react';
 import Mentions from '../src';
 import { simulateInput } from './util';
 
@@ -79,13 +79,21 @@ describe('DropdownMenu', () => {
       jest.runAllTimers();
     });
 
-    await act(async () => {
-      fireEvent.blur(textarea);
-
-      const menuItems = container.querySelectorAll('.rc-mentions-menu-item');
+    await waitFor(() => {
+      const menuItems = document.querySelectorAll(
+        '.rc-mentions-dropdown-menu-item',
+      );
       expect(menuItems.length).toBeGreaterThan(1);
+    });
+
+    const menuItems = document.querySelectorAll(
+      '.rc-mentions-dropdown-menu-item',
+    );
+
+    await act(async () => {
       fireEvent.mouseEnter(menuItems[1]);
 
+      fireEvent.blur(textarea);
       jest.runAllTimers();
     });
 

--- a/tests/DropdownMenu.spec.tsx
+++ b/tests/DropdownMenu.spec.tsx
@@ -57,7 +57,7 @@ describe('DropdownMenu', () => {
     scrollIntoViewMock.mockRestore();
   });
 
-  it('should NOT scroll into view when input is NOT focused', async () => {
+  it('should NOT scroll and hit the return statement when input blurs but menu is arguably open', async () => {
     const { container } = render(
       <Mentions defaultValue="" options={generateOptions} />,
     );
@@ -73,19 +73,15 @@ describe('DropdownMenu', () => {
       jest.runAllTimers();
     });
 
-    scrollIntoViewMock.mockClear();
-
     await act(async () => {
       fireEvent.blur(textarea);
-      jest.runAllTimers();
-    });
 
-    await act(async () => {
       const menuItems = document.querySelectorAll('.rc-mentions-menu-item');
       if (menuItems.length > 1) {
         fireEvent.mouseEnter(menuItems[1]);
-        jest.runAllTimers();
       }
+
+      jest.runAllTimers();
     });
 
     expect(scrollIntoViewMock).not.toHaveBeenCalled();

--- a/tests/DropdownMenu.spec.tsx
+++ b/tests/DropdownMenu.spec.tsx
@@ -9,12 +9,18 @@ describe('DropdownMenu', () => {
     label: `item-${index}`,
   }));
 
+  let originResizeObserver: any;
   beforeAll(() => {
-    global.ResizeObserver = class ResizeObserver {
+    originResizeObserver = (global as any).ResizeObserver;
+    (global as any).ResizeObserver = class ResizeObserver {
       observe() {}
       unobserve() {}
       disconnect() {}
     };
+  });
+
+  afterAll(() => {
+    (global as any).ResizeObserver = originResizeObserver;
   });
 
   beforeEach(() => {
@@ -23,7 +29,7 @@ describe('DropdownMenu', () => {
 
   afterEach(() => {
     jest.useRealTimers();
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should scroll into view when navigating with keyboard (Focused)', async () => {
@@ -76,10 +82,9 @@ describe('DropdownMenu', () => {
     await act(async () => {
       fireEvent.blur(textarea);
 
-      const menuItems = document.querySelectorAll('.rc-mentions-menu-item');
-      if (menuItems.length > 1) {
-        fireEvent.mouseEnter(menuItems[1]);
-      }
+      const menuItems = container.querySelectorAll('.rc-mentions-menu-item');
+      expect(menuItems.length).toBeGreaterThan(1);
+      fireEvent.mouseEnter(menuItems[1]);
 
       jest.runAllTimers();
     });


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/56134
<img width="2074" height="1180" alt="96592087a1104b3fbf01f6a0553529a1" src="https://github.com/user-attachments/assets/fa31516d-41d6-48c7-b6bb-b61a5e5cd18c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在组件上下文中透传输入框引用，组件树内可访问输入框以改善交互体验。

* **修复**
  * 优化下拉菜单滚动逻辑：仅在输入框确实聚焦时执行滚动，避免失焦或鼠标交互时的意外滚动。

* **测试**
  * 强化测试覆盖：新增“失焦不滚动”验证、DOM API mock 及定时器与事件处理清理。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->