### PR TITLE
chore: remove @rc-component/textarea dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@rc-component/input": "~1.3.0",
     "@rc-component/menu": "~1.2.0",
-    "@rc-component/textarea": "~1.2.0",
     "@rc-component/trigger": "^3.0.0",
     "@rc-component/util": "^1.3.0",
     "clsx": "^2.1.1"

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -1,9 +1,8 @@
 import { clsx } from 'clsx';
-import { BaseInput } from '@rc-component/input';
+import { BaseInput, TextArea } from '@rc-component/input';
 import type { HolderRef } from '@rc-component/input/lib/BaseInput';
 import type { CommonInputProps } from '@rc-component/input/lib/interface';
-import type { TextAreaProps, TextAreaRef } from '@rc-component/textarea';
-import TextArea from '@rc-component/textarea';
+import type { TextAreaProps, TextAreaRef } from '@rc-component/input';
 import toArray from '@rc-component/util/lib/Children/toArray';
 import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
 import KeyCode from '@rc-component/util/lib/KeyCode';


### PR DESCRIPTION
## 变更说明

本次调整移除了 `@rc-component/textarea` 依赖，并将 `Mentions` 内部使用的 `TextArea`、`TextAreaProps`、`TextAreaRef` 全部切换为 `@rc-component/input` 提供的实现。

这是一次内部依赖迁移，不涉及 `Mentions` 对外 API 变更。

## 具体改动

- 移除 `@rc-component/textarea` 依赖
- `Mentions` 改为从 `@rc-component/input` 引入 `TextArea`
- `Mentions` 相关 textarea 类型改为使用 `@rc-component/input` 导出的类型



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 优化内部依赖配置，提升代码组织结构的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->