### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,17 +45,19 @@
     ]
   },
   "dependencies": {
-    "@rc-component/input": "~1.3.0",
+    "@rc-component/input": "~1.3.1",
     "@rc-component/menu": "~1.3.0",
     "@rc-component/trigger": "^3.0.0",
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.62.0",
+    "@typescript-eslint/parser": "^5.62.0",
     "@types/node": "^24.5.2",
     "@types/react": "^18.0.8",
     "@types/react-dom": "^18.0.3",
@@ -63,7 +65,7 @@
     "@umijs/fabric": "^3.0.0",
     "dumi": "^2.0.18",
     "eslint": "^8.0.0",
-    "eslint-plugin-jest": "^28.11.0",
+    "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-unicorn": "^56.0.1",
     "father": "^4.0.0",
     "gh-pages": "^5.0.0",

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -1,12 +1,17 @@
 import { clsx } from 'clsx';
 import { BaseInput, TextArea } from '@rc-component/input';
-import type { HolderRef } from '@rc-component/input/lib/BaseInput';
-import type { CommonInputProps } from '@rc-component/input/lib/interface';
-import type { TextAreaProps, TextAreaRef } from '@rc-component/input';
-import toArray from '@rc-component/util/lib/Children/toArray';
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import useId from '@rc-component/util/lib/hooks/useId';
+import type {
+  BaseInputProps,
+  HolderRef,
+  TextAreaProps,
+  TextAreaRef,
+} from '@rc-component/input';
+import {
+  KeyCode,
+  toArray,
+  useControlledState,
+  useId,
+} from '@rc-component/util';
 import React, {
   forwardRef,
   useContext,
@@ -69,7 +74,7 @@ export interface MentionsProps extends BaseTextareaAttrs {
   popupClassName?: string;
   children?: React.ReactNode;
   options?: DataDrivenOptionProps[];
-  classNames?: CommonInputProps['classNames'] & {
+  classNames?: BaseInputProps['classNames'] & {
     mentions?: string;
     textarea?: string;
     popup?: string;

--- a/tests/FullProcess.spec.tsx
+++ b/tests/FullProcess.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
 import type { MentionsProps } from '../src';
 import Mentions from '../src';

--- a/tests/Mentions.spec.tsx
+++ b/tests/Mentions.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React, { createRef } from 'react';
 import { act } from 'react-dom/test-utils';
 import type { MentionsProps } from '../src';

--- a/tests/__snapshots__/AllowClear.spec.tsx.snap
+++ b/tests/__snapshots__/AllowClear.spec.tsx.snap
@@ -13,7 +13,6 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-mentions-clear-icon rc-mentions-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -35,7 +34,6 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-mentions-clear-icon rc-mentions-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -57,7 +55,6 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-mentions-clear-icon rc-mentions-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -79,7 +76,6 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-mentions-clear-icon rc-mentions-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -101,7 +97,6 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-mentions-clear-icon rc-mentions-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖
@@ -123,7 +118,6 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-mentions-clear-icon rc-mentions-clear-icon-hidden"
-      tabindex="-1"
       type="button"
     >
       ✖


### PR DESCRIPTION
## 背景

移除源码中对其他 rc 包 `lib` 目录的直接依赖，统一改为从包根入口导入，避免依赖构建产物内部路径。

## 调整

- 升级 `@rc-component/input` 到已发布的 `~1.3.1`，使用其根入口导出的类型。
- 升级 `@rc-component/util` 与 `@rc-component/father-plugin`，使用 father-plugin 统一检查 rc 深路径导入。
- 将 Mentions 源码和测试中的 util/input 深路径导入替换为包根导入。
- 更新 `allowClear` 相关快照，以匹配新版 input 的输出。

## 验证

- `npm run lint`
- `npm run compile`
- `npm test -- --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级核心依赖版本以增强兼容性和稳定性
  * 调整开发工具依赖配置

* **Refactor**
  * 优化模块导入结构以提高代码可维护性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/mentions/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->