### PR TITLE
feat: support popupRender to customize Mentions dropdown menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ React.render(<Demo />, container);
 | autoSize          | Textarea height autosize feature, can be set to `true\|false` or an object `{ minRows: 2, maxRows: 6 }` | `boolean \| object`                                        | -           |
 | onPressEnter      | The callback function that is triggered when Enter key is pressed                                       | `function(e)`                                              | -           |
 | onResize          | The callback function that is triggered when textarea resize                                            | `function({ width, height })`                              | -           |
-| popupRender       | Customize the dropdown menu rendering                                                                   | `(menu: ReactNode) => ReactNode`                           | -           |
+| popupRender       | Customize the dropdown menu rendering                                                                   | `(menu: React.ReactElement) => ReactNode`                  | -           |
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ React.render(<Demo />, container);
 | autoSize          | Textarea height autosize feature, can be set to `true\|false` or an object `{ minRows: 2, maxRows: 6 }` | `boolean \| object`                                        | -           |
 | onPressEnter      | The callback function that is triggered when Enter key is pressed                                       | `function(e)`                                              | -           |
 | onResize          | The callback function that is triggered when textarea resize                                            | `function({ width, height })`                              | -           |
+| popupRender       | Customize the dropdown menu rendering                                                                   | `(menu: ReactNode) => ReactNode`                           | -           |
 
 ### Methods
 

--- a/src/KeywordTrigger.tsx
+++ b/src/KeywordTrigger.tsx
@@ -52,7 +52,7 @@ interface KeywordTriggerProps {
   getPopupContainer?: () => HTMLElement;
   popupClassName?: string;
   popupStyle?: React.CSSProperties;
-  popupRender?: (menu: React.ReactNode) => React.ReactNode;
+  popupRender?: (menu: React.ReactElement) => React.ReactNode;
 }
 
 const KeywordTrigger: FC<KeywordTriggerProps> = props => {

--- a/src/KeywordTrigger.tsx
+++ b/src/KeywordTrigger.tsx
@@ -52,6 +52,7 @@ interface KeywordTriggerProps {
   getPopupContainer?: () => HTMLElement;
   popupClassName?: string;
   popupStyle?: React.CSSProperties;
+  popupRender?: (menu: React.ReactNode) => React.ReactNode;
 }
 
 const KeywordTrigger: FC<KeywordTriggerProps> = props => {
@@ -66,6 +67,7 @@ const KeywordTrigger: FC<KeywordTriggerProps> = props => {
     popupStyle,
     direction,
     placement,
+    popupRender,
   } = props;
 
   const dropdownPrefix = `${prefixCls}-dropdown`;
@@ -89,11 +91,15 @@ const KeywordTrigger: FC<KeywordTriggerProps> = props => {
     return popupPlacement;
   }, [direction, placement]);
 
+  const dropdownPopup = popupRender
+    ? popupRender(dropdownElement)
+    : dropdownElement;
+
   return (
     <Trigger
       prefixCls={dropdownPrefix}
       popupVisible={visible}
-      popup={dropdownElement}
+      popup={dropdownPopup}
       popupPlacement={dropdownPlacement}
       popupMotion={{ motionName: transitionName }}
       builtinPlacements={BUILT_IN_PLACEMENTS}

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -85,6 +85,12 @@ export interface MentionsProps extends BaseTextareaAttrs {
     popup?: React.CSSProperties;
   };
   onPopupScroll?: (event: React.UIEvent<HTMLDivElement>) => void;
+  /**
+   * Customize the dropdown menu rendering
+   * @param menu The default dropdown menu
+   * @returns The customized dropdown menu
+   */
+  popupRender?: (menu: React.ReactNode) => React.ReactNode;
 }
 
 export interface MentionsRef {
@@ -150,6 +156,7 @@ const InternalMentions = forwardRef<MentionsRef, InternalMentionsProps>(
       // @ts-expect-error
       visible,
       onPopupScroll,
+      popupRender,
 
       // Rest
       ...restProps
@@ -607,6 +614,7 @@ const InternalMentions = forwardRef<MentionsRef, InternalMentionsProps>(
                 getPopupContainer={getPopupContainer}
                 popupClassName={clsx(popupClassName, mentionClassNames?.popup)}
                 popupStyle={styles?.popup}
+                popupRender={popupRender}
               >
                 <span>{mergedMeasurePrefix}</span>
               </KeywordTrigger>

--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -90,7 +90,7 @@ export interface MentionsProps extends BaseTextareaAttrs {
    * @param menu The default dropdown menu
    * @returns The customized dropdown menu
    */
-  popupRender?: (menu: React.ReactNode) => React.ReactNode;
+  popupRender?: (menu: React.ReactElement) => React.ReactNode;
 }
 
 export interface MentionsRef {

--- a/tests/Mentions.spec.tsx
+++ b/tests/Mentions.spec.tsx
@@ -484,4 +484,24 @@ describe('Mentions', () => {
       expect(textarea).toHaveStyle({ resize: 'vertical' });
     });
   });
+
+  describe('popupRender', () => {
+    it('should render custom popup content', () => {
+      const { container, baseElement } = renderMentions({
+        popupRender: menu => (
+          <div className="custom-popup">
+            <div className="custom-header">Custom Header</div>
+            {menu}
+          </div>
+        ),
+      });
+
+      simulateInput(container, '@');
+
+      expect(baseElement.querySelector('.custom-header')).toBeTruthy();
+      expect(
+        baseElement.querySelector('.rc-mentions-dropdown-menu'),
+      ).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
### 🤔 这是一个...

- [x] 🆕 新功能
- [ ] 🐛 Bug 修复
- [ ] 📝 文档更新
- [ ] 🧹 代码风格修改
- [ ] 👽 重构
- [x] ✅ 测试
- [ ] ⚡ 性能优化
- [ ] ❌ 破坏性变更
- [ ] ❌ 其他

### 💡 背景和解决方案

为 Mentions 组件实现 `popupRender` 属性，允许自定义下拉菜单，与 antd Select 组件保持一致。

该功能请求来自：https://github.com/ant-design/ant-design/issues/31193

### 📋 变更摘要

- 为 Mentions 组件添加 `popupRender` 属性
- 传递到 KeywordTrigger 组件
- 用户可以包装或替换下拉菜单内容

### 🔗 相关链接

- https://github.com/ant-design/ant-design/issues/31193
- 相关：antd Select `popupRender`

### ✅ 检查清单

- [x] 确保代码风格符合规范
- [x] 为新功能添加测试
- [x] 运行测试确保通过
- [x] 更新文档

### 📝 使用示例

```tsx
<Mentions
  popupRender={(menu) => (
    <div className="custom-popup">
      <div className="custom-header">自定义头部</div>
      {menu}
    </div>
  )}
/>
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Mentions 组件新增下拉内容自定义能力，可通过 `popupRender` 传入自定义渲染结果。
  * 自定义内容可在保留原有下拉菜单结构的同时，扩展顶部区域或其他展示内容。
* **测试**
  * 增加了相关用例，覆盖自定义下拉渲染与默认菜单容器共存的场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->