### PR TITLE
fix: ignore the Enter that confirms an IME composition when selecting a mention

### DIFF
--- a/src/Mentions.tsx
+++ b/src/Mentions.tsx
@@ -402,6 +402,13 @@ const InternalMentions = forwardRef<MentionsRef, InternalMentionsProps>(
       } else if (which === KeyCode.ESC) {
         stopMeasure();
       } else if (which === KeyCode.ENTER) {
+        // The Enter key that only confirms an IME composition should not select
+        // the active option. On some browsers (e.g. Safari) this keydown still
+        // reports `which === ENTER` while `isComposing` is true, the same case
+        // rc-select guards against in its input.
+        if (event.nativeEvent.isComposing) {
+          return;
+        }
         // Measure hit
         event.preventDefault();
         // loading skip

--- a/tests/Composition.spec.tsx
+++ b/tests/Composition.spec.tsx
@@ -1,0 +1,63 @@
+import { act, createEvent, fireEvent, render } from '@testing-library/react';
+import { KeyCode } from '@rc-component/util';
+import React from 'react';
+import Mentions from '../src';
+import { simulateInput } from './util';
+
+// The keydown that confirms an IME composition still reports `which === ENTER`
+// on some browsers (e.g. Safari) while `isComposing` is true.
+function imeEnterKeyDown(element: HTMLElement) {
+  const event = createEvent.keyDown(element, { keyCode: KeyCode.ENTER });
+  Object.defineProperties(event, {
+    which: { get: () => KeyCode.ENTER },
+    isComposing: { get: () => true },
+  });
+  act(() => {
+    fireEvent(element, event);
+  });
+}
+
+const options = [
+  { value: 'bamboo', label: 'Bamboo' },
+  { value: 'cat', label: 'Cat' },
+];
+
+describe('Mentions.Composition', () => {
+  it('does not select the active option when Enter only confirms the IME composition', () => {
+    const onChange = jest.fn();
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Mentions options={options} onChange={onChange} onSelect={onSelect} />,
+    );
+
+    simulateInput(container, '@');
+
+    // Typing the trigger fires onChange, so only watch what the Enter does.
+    onChange.mockClear();
+    onSelect.mockClear();
+
+    imeEnterKeyDown(container.querySelector('textarea'));
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('still selects the active option on a normal Enter', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Mentions options={options} onSelect={onSelect} />,
+    );
+
+    simulateInput(container, '@');
+
+    fireEvent.keyDown(container.querySelector('textarea'), {
+      keyCode: KeyCode.ENTER,
+      which: KeyCode.ENTER,
+    });
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 'bamboo' }),
+      '@',
+    );
+  });
+});


### PR DESCRIPTION
When the suggestion dropdown is open and an option is highlighted, pressing Enter selects it. On browsers that report the IME commit keydown as `which === ENTER` while `isComposing` is true (Safari is the common case), the Enter that only confirms an IME composition gets treated as a selection. So while typing a Chinese or Japanese name after the trigger, confirming the conversion replaces the composed text with the highlighted option instead of just committing what was typed.

This guards the Enter branch in `onInternalKeyDown` with `event.nativeEvent.isComposing`. A composing Enter now returns early and leaves the IME to commit the text, while a real Enter still selects the option. rc-select already ignores Enter while composing in its input, so this brings Mentions in line.

Tests cover both cases: a composing Enter does not select, and a normal Enter still selects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复了输入法组合输入（IME）过程中按 Enter 误触发选择的问题。
  - 现在在中文输入等组合状态下，Enter 不会提前确认候选项；普通 Enter 仍会正常选中当前高亮项并触发选择回调。

- **Tests**
  - 新增覆盖组合输入与普通 Enter 场景的回归测试，确保上述行为稳定可用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->